### PR TITLE
fix favicon path

### DIFF
--- a/src/templates/app.html
+++ b/src/templates/app.html
@@ -5,8 +5,8 @@
     <title>Greenwood Demo - GitHub Pages</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="shortcut icon" href="/favicon.ico"/>
-    <link rel="icon" href="/favicon.ico"/>
+    <link rel="shortcut icon" href="/greenwood-demo-github-pages/favicon.ico"/>
+    <link rel="icon" href="/greenwood-demo-github-pages/favicon.ico"/>
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro">
     <link rel="stylesheet" href="../styles/main.css">


### PR DESCRIPTION
Noticed no favicon was showing
![Screenshot 2023-11-08 at 9 23 50 PM](https://github.com/ProjectEvergreen/greenwood-demo-github-pages/assets/895923/4bc5a8ec-9fbb-4835-b393-7663a333252d)

now shows locally
![Screenshot 2023-11-08 at 9 24 16 PM](https://github.com/ProjectEvergreen/greenwood-demo-github-pages/assets/895923/d333654c-2b50-41f2-8e55-77b2a9bc5796)